### PR TITLE
Added NSMicrophoneUsageDescription

### DIFF
--- a/examples/Terminal/Terminal/Info.plist
+++ b/examples/Terminal/Terminal/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The microphone is needed for this app to function.</string>	
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
NSMicrophoneUsageDescription is required in iOS 10. Without it, app crashes when attempting to use mic.